### PR TITLE
Add refresh controls method in av canvas

### DIFF
--- a/.changeset/rotten-oranges-collect.md
+++ b/.changeset/rotten-oranges-collect.md
@@ -1,0 +1,5 @@
+---
+'@webav/av-canvas': patch
+---
+
+feat: add refreshControls method in av-canvas

--- a/packages/av-canvas/src/sprites/render-ctrl.ts
+++ b/packages/av-canvas/src/sprites/render-ctrl.ts
@@ -8,7 +8,10 @@ export function renderCtrls(
   cvsEl: HTMLCanvasElement,
   sprMng: SpriteManager,
   rectCtrlsGetter: (rect: Rect) => RectCtrls,
-): () => void {
+): {
+  destroy: () => void;
+  refresh: () => void;
+} {
   const cvsRatio = {
     w: cvsEl.clientWidth / cvsEl.width,
     h: cvsEl.clientHeight / cvsEl.height,
@@ -64,13 +67,30 @@ export function renderCtrls(
   window.addEventListener('pointerup', onWinowUp);
   window.addEventListener('pointermove', onMove);
 
-  return () => {
+  // 新增的刷新函数，可以在外部修改rect后手动调用
+  const refresh = (): void => {
+    if (sprMng.activeSprite == null) return;
+    syncCtrlElPos(
+      sprMng.activeSprite,
+      rectEl,
+      ctrlsEl,
+      cvsRatio,
+      rectCtrlsGetter,
+    );
+  };
+
+  const destroy = (): void => {
     observer.disconnect();
     offSprChange();
     rectEl.remove();
     cvsEl.removeEventListener('pointerdown', onDown);
     window.removeEventListener('pointerup', onWinowUp);
     window.removeEventListener('pointermove', onMove);
+  };
+
+  return {
+    destroy,
+    refresh,
   };
 }
 


### PR DESCRIPTION
使用av-canvas时经常会有在外部修改VisibleSprite的rect属性情况，尤其是自定义clip（典型场景是自定义文字clip需要根据绘制情况返回宽高并更新到VisibleSprite），目前这些外部修改不能触发ctrls的调整，考虑到直接监听更新不太合适，所以添加了一个更新方法。