### PR TITLE
Fix  stuttering when start playing with large videos

### DIFF
--- a/.changeset/ninety-scissors-remain.md
+++ b/.changeset/ninety-scissors-remain.md
@@ -1,0 +1,5 @@
+---
+'@webav/av-canvas': patch
+---
+
+fix: stuttering when start playing with large videos

--- a/packages/av-canvas/src/av-canvas.ts
+++ b/packages/av-canvas/src/av-canvas.ts
@@ -269,7 +269,7 @@ export class AVCanvas {
     }
 
     this.#updateRenderTime(opts.start);
-    this.#spriteManager.getSprites({ time: false }).forEach((vs) => {
+    this.#spriteManager.getSprites({ time: true }).forEach((vs) => {
       const { offset, duration } = vs.time;
       const selfOffset = this.#renderTime - offset;
       vs.preFrame(selfOffset > 0 && selfOffset < duration ? selfOffset : 0);


### PR DESCRIPTION
添加较大视频或大量高质量视频时，在av-canvas中play会造成开始阶段的卡顿现象，因此修改了play时preFrame的机制，仅初始化当前时间需要展示的vs。