### PR TITLE
Adds Opus codec config support

### DIFF
--- a/packages/av-cliper/src/combinator.ts
+++ b/packages/av-cliper/src/combinator.ts
@@ -10,7 +10,7 @@ export interface ICombinatorOpts {
   fps?: number;
   bgColor?: string;
   videoCodec?: string;
-  audioCodec?: string;
+  audioCodec?: 'opus' | 'aac';
   opusConfig?: object;
   /**
    * false 合成的视频文件中排除音轨
@@ -91,20 +91,13 @@ export class Combinator {
           })
         ).supported ??
           false) &&
-        ((
-          await self.AudioEncoder.isConfigSupported({
-            codec: DEFAULT_AUDIO_CONF.codec,
-            sampleRate: DEFAULT_AUDIO_CONF.sampleRate,
-            numberOfChannels: DEFAULT_AUDIO_CONF.channelCount,
-          })
-        ).supported) ||
         (
           await self.AudioEncoder.isConfigSupported({
-            codec: args.audioCodec,
+            codec: args.audioCodec ?? DEFAULT_AUDIO_CONF.codec,
             sampleRate: DEFAULT_AUDIO_CONF.sampleRate,
             numberOfChannels: DEFAULT_AUDIO_CONF.channelCount,
           })
-        ).supported)) ??
+        ).supported) ??
       false
     );
   }

--- a/packages/av-cliper/src/combinator.ts
+++ b/packages/av-cliper/src/combinator.ts
@@ -1,7 +1,7 @@
-import { Log, EventTool, file2stream, recodemux } from '@webav/internal-utils';
-import { OffscreenSprite } from './sprite/offscreen-sprite';
+import { EventTool, file2stream, Log, recodemux } from '@webav/internal-utils';
 import { sleep } from './av-utils';
 import { DEFAULT_AUDIO_CONF } from './clips';
+import { OffscreenSprite } from './sprite/offscreen-sprite';
 
 export interface ICombinatorOpts {
   width?: number;
@@ -69,6 +69,7 @@ export class Combinator {
     args: {
       videoCodec?: string;
       audioCodec?: string;
+      hardwareAcceleration?: HardwarePreference;
       width?: number;
       height?: number;
       bitrate?: number;
@@ -85,6 +86,7 @@ export class Combinator {
         ((
           await self.VideoEncoder.isConfigSupported({
             codec: args.videoCodec ?? 'avc1.42E032',
+            hardwareAcceleration: args.hardwareAcceleration ?? 'no-preference',
             width: args.width ?? 1920,
             height: args.height ?? 1080,
             bitrate: args.bitrate ?? 7e6,
@@ -182,8 +184,17 @@ export class Combinator {
   }
 
   #startRecodeMux(duration: number) {
-    const { fps, width, height, videoCodec, audioCodec, opusConfig, bitrate, audio, metaDataTags } =
-      this.#opts;
+    const {
+      fps,
+      width,
+      height,
+      videoCodec,
+      audioCodec,
+      opusConfig,
+      bitrate,
+      audio,
+      metaDataTags,
+    } = this.#opts;
     const recodeMuxer = recodemux({
       video: this.#hasVideoTrack
         ? {

--- a/packages/internal-utils/src/recodemux.ts
+++ b/packages/internal-utils/src/recodemux.ts
@@ -361,7 +361,7 @@ function createVideoEncoder(
 
 //codec mapping
 const codecTypeMap = {
-  'aac': "m4a",
+  'aac': "mp4a",
   'opus': "Opus"
 },
 codecMap = {

--- a/packages/internal-utils/src/recodemux.ts
+++ b/packages/internal-utils/src/recodemux.ts
@@ -29,6 +29,7 @@ interface IRecodeMuxOpts {
    */
   audio: {
     codec: 'opus' | 'aac';
+    opusConfig: object;
     sampleRate: number;
     channelCount: number;
   } | null;
@@ -358,6 +359,16 @@ function createVideoEncoder(
   return encoder;
 }
 
+//codec mapping
+const codecTypeMap = {
+  'aac': "m4a",
+  'opus': "Opus"
+},
+codecMap = {
+  'aac': "mp4a.40.2",
+  'opus': "opus"
+};
+
 function encodeAudioTrack(
   audioOpts: NonNullable<IRecodeMuxOpts['audio']>,
   mp4File: MP4File,
@@ -368,7 +379,8 @@ function encodeAudioTrack(
     samplerate: audioOpts.sampleRate,
     channel_count: audioOpts.channelCount,
     hdlr: 'soun',
-    type: audioOpts.codec === 'aac' ? 'mp4a' : 'Opus',
+    //map codec to type
+    type: codecTypeMap[audioOpts.codec],
     name: 'Track created with WebAV',
   };
 
@@ -385,7 +397,9 @@ function encodeAudioTrack(
   });
 
   const encoderConf = {
-    codec: audioOpts.codec === 'aac' ? 'mp4a.40.2' : 'opus',
+    //map codec to AudioEncoder codec
+    codec: codecMap[audioOpts.codec],
+    opus: audioOpts.opusConfig,
     sampleRate: audioOpts.sampleRate,
     numberOfChannels: audioOpts.channelCount,
     bitrate: 128_000,


### PR DESCRIPTION
 Fixes Issue #429 
 
 Internally opus was supported but a hardcoded config of `aac` was being sent to the AudioEncoder. 
 
 This became a problem attempting to use an AudioEncoder libav polyfill for IOS and Firefox support. Which doesn't support aac by default and requires opus codec.
 
 A new config called `opusConfig` is added to add opus codec specific settings. Which is configured on the `opus` property.