### PR TITLE
fix: audio/video sync drift in `fixMP4BoxFileDuration`

### DIFF
--- a/packages/av-cliper/src/mp4-utils/index.ts
+++ b/packages/av-cliper/src/mp4-utils/index.ts
@@ -223,12 +223,14 @@ async function concatStreamsToMP4BoxFile(
       });
     });
     if (lastVSamp != null) {
-      vDTS += lastVSamp.dts;
-      vCTS += lastVSamp.cts;
+      vDTS += lastVSamp.dts + lastVSamp.duration;
+      vCTS += lastVSamp.cts + lastVSamp.duration;
     }
-    if (lastASamp != null) {
-      aDTS += lastASamp.dts;
-      aCTS += lastASamp.cts;
+    if (lastASamp != null && lastVSamp != null) {
+      // Force audio timing to match video timing (converted to audio timescale)
+      const videoToAudioRatio = lastASamp.timescale / lastVSamp.timescale;
+      aDTS = Math.round(vDTS * videoToAudioRatio);
+      aCTS = Math.round(vCTS * videoToAudioRatio);
     }
   }
 }

--- a/packages/av-cliper/src/mp4-utils/index.ts
+++ b/packages/av-cliper/src/mp4-utils/index.ts
@@ -181,6 +181,12 @@ async function concatStreamsToMP4BoxFile(
   let lastVSamp: any = null;
   let lastASamp: any = null;
   for (const stream of streams) {
+    // reset first sample timestamps for each stream to enable normalization
+    let firstVDTS: number | null = null;
+    let firstVCTS: number | null = null;
+    let firstADTS: number | null = null;
+    let firstACTS: number | null = null;
+
     await new Promise<void>(async (resolve) => {
       autoReadStream(stream.pipeThrough(new SampleTransform()), {
         onDone: resolve,
@@ -203,10 +209,32 @@ async function concatStreamsToMP4BoxFile(
             const offsetCTS = type === 'video' ? vCTS : aCTS;
 
             samples.forEach((s) => {
+              let normalizedDTS: number;
+              let normalizedCTS: number;
+
+              if (type === 'video') {
+                // capture first sample timestamps for normalization
+                if (firstVDTS === null) {
+                  firstVDTS = s.dts;
+                  firstVCTS = s.cts;
+                }
+                // normalize to start from 0, then add offset
+                normalizedDTS = s.dts - firstVDTS;
+                normalizedCTS = s.cts - (firstVCTS ?? 0);
+              } else {
+                // same for audio
+                if (firstADTS === null) {
+                  firstADTS = s.dts;
+                  firstACTS = s.cts;
+                }
+                normalizedDTS = s.dts - firstADTS;
+                normalizedCTS = s.cts - (firstACTS ?? 0);
+              }
+
               outfile.addSample(trackId, s.data, {
                 duration: s.duration,
-                dts: s.dts + offsetDTS,
-                cts: s.cts + offsetCTS,
+                dts: normalizedDTS + offsetDTS,
+                cts: normalizedCTS + offsetCTS,
                 is_sync: s.is_sync,
               });
             });
@@ -222,12 +250,16 @@ async function concatStreamsToMP4BoxFile(
         },
       });
     });
-    if (lastVSamp != null) {
-      vDTS += lastVSamp.dts + lastVSamp.duration;
-      vCTS += lastVSamp.cts + lastVSamp.duration;
+    // calculate offsets based on normalized timestamps
+    if (lastVSamp != null && firstVDTS !== null && firstVCTS !== null) {
+      // duration of this normalized stream
+      const normalizedVDTS = lastVSamp.dts - firstVDTS + lastVSamp.duration;
+      const normalizedVCTS = lastVSamp.cts - firstVCTS + lastVSamp.duration;
+      vDTS += normalizedVDTS;
+      vCTS += normalizedVCTS;
     }
+    // coerce audio timing to match video timing by converting video timescale to audio timescale
     if (lastASamp != null && lastVSamp != null) {
-      // Force audio timing to match video timing (converted to audio timescale)
       const videoToAudioRatio = lastASamp.timescale / lastVSamp.timescale;
       aDTS = Math.round(vDTS * videoToAudioRatio);
       aCTS = Math.round(vCTS * videoToAudioRatio);


### PR DESCRIPTION
Hello! This PR fixes a small issue leading to audio/video sync drift when using `fastConcatMP4` to concatenate mp4s.

The problem: if input MP4 streams to `fastConcatMP4` contain internal timestamp offsets that don't start at 0, cumulative A/V drift occurs during concatenation, making the video not match the audio. This was affecting *both* audio and video, a video output from `fastConcatMP4` is both the wrong duration *and* showing a/v drift, and also dropping frames due to the incorrectly calculated durations.

This fixes it by normalizing sample timestamps within each stream to start from 0 before applying concatenation offsets, ensuring the correct duration is calculated. This also synchronizes **audio timing to the video timeline** to maintain correct a/v sync.

I don't have a repro case I can share right now but can provide if needed.