### PR TITLE
fix: 修复Sprite动画最后一帧有偏差的问题

### DIFF
--- a/packages/av-cliper/src/dom-utils.ts
+++ b/packages/av-cliper/src/dom-utils.ts
@@ -34,7 +34,6 @@ export async function renderTxt2Img(
   } = {},
 ): Promise<HTMLImageElement> {
   const div = createEl('pre');
-  if (!cssText.includes('line-height')) { cssText += 'line-height: 1;'; }
   div.style.cssText = `margin: 0; ${cssText}; position: fixed;`;
   div.textContent = txt;
   document.body.appendChild(div);

--- a/packages/av-cliper/src/dom-utils.ts
+++ b/packages/av-cliper/src/dom-utils.ts
@@ -34,6 +34,7 @@ export async function renderTxt2Img(
   } = {},
 ): Promise<HTMLImageElement> {
   const div = createEl('pre');
+  if (!cssText.includes('line-height')) { cssText += 'line-height: 1;'; }
   div.style.cssText = `margin: 0; ${cssText}; position: fixed;`;
   div.textContent = txt;
   document.body.appendChild(div);

--- a/packages/av-cliper/src/sprite/base-sprite.ts
+++ b/packages/av-cliper/src/sprite/base-sprite.ts
@@ -215,6 +215,7 @@ export function linearTimeFn(
   if (offsetTime / opts.duration > opts.iterCount) {
     offsetTime = opts.duration * opts.iterCount;
   }
+  
   const t = offsetTime % opts.duration;
 
   const process = offsetTime === opts.duration ? 1 : t / opts.duration;

--- a/packages/av-cliper/src/sprite/base-sprite.ts
+++ b/packages/av-cliper/src/sprite/base-sprite.ts
@@ -211,9 +211,10 @@ export function linearTimeFn(
   kf: TAnimationKeyFrame,
   opts: Required<IAnimationOpts>,
 ): Partial<TAnimateProps> {
-  const offsetTime = time - opts.delay;
-  if (offsetTime / opts.duration >= opts.iterCount) return {};
-
+  let offsetTime = time - opts.delay;
+  if (offsetTime / opts.duration > opts.iterCount) {
+    offsetTime = opts.duration * opts.iterCount;
+  }
   const t = offsetTime % opts.duration;
 
   const process = offsetTime === opts.duration ? 1 : t / opts.duration;

--- a/packages/av-cliper/src/sprite/base-sprite.ts
+++ b/packages/av-cliper/src/sprite/base-sprite.ts
@@ -211,14 +211,13 @@ export function linearTimeFn(
   kf: TAnimationKeyFrame,
   opts: Required<IAnimationOpts>,
 ): Partial<TAnimateProps> {
-  let offsetTime = time - opts.delay;
-  if (offsetTime / opts.duration > opts.iterCount) {
-    offsetTime = opts.duration * opts.iterCount;
-  }
-  
+  const offsetTime = time - opts.delay;
   const t = offsetTime % opts.duration;
+  const process =
+    offsetTime / opts.duration >= opts.iterCount || offsetTime === opts.duration
+      ? 1
+      : t / opts.duration;
 
-  const process = offsetTime === opts.duration ? 1 : t / opts.duration;
   const idx = kf.findIndex((it) => it[0] >= process);
   if (idx === -1) return {};
 


### PR DESCRIPTION
判断当前时间大于动画时间，则统一渲染为动画最后一帧的效果，以避免最后一帧的偏差 #460 